### PR TITLE
Categoría nueva, preguntas repetidas y bugs

### DIFF
--- a/questionservice/question-queries.js
+++ b/questionservice/question-queries.js
@@ -48,7 +48,7 @@ queries["es"] = {
         SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es". }
       }
       LIMIT 100
-      `, "¿Cuál es el nombre de este futbolista?"]
+      `, "¿Quién es esta persona famosa?"]
             ]
 }
 

--- a/questionservice/question-service.js
+++ b/questionservice/question-service.js
@@ -25,13 +25,7 @@ let questions = [];
 let currentQuestionIndex = 0;
 var maxQuestions = 5;
 
-var correct = "";
-var question = "";
-var image = "";
-var options = [];
-var questionToSave = null;
 var randomQuery;
-var randomIndexes = [];
 var queries = [
     `SELECT DISTINCT ?option ?optionLabel ?imageLabel
       WHERE {
@@ -131,19 +125,22 @@ var questionImage = "";
  */
 async function loadQuestions(category = "All") {
     questions = [];
+    currentQuestionIndex = 0;
+    queriesAndQuestions = getQueriesAndQuestions(imagesQueries);
+
     try {
-        let queryPool = queries;
+        //let queryPool = queries;
         let questionPrompt = "¿Qué muestra esta imagen?"; // Default question
 
-            await getQueriesByCategory(category);
-            queryPool = queries;
+        await getQueriesByCategory(category);
+        let queryPool = queries;
 
-            // Set the question text based on the current category
-            const categoryIndex = categories.indexOf(category);
+        // Set the question text based on the current category
+        const categoryIndex = categories.indexOf(category);
 
-            if (categoryIndex !== -1 && categoryIndex < possiblesQuestions.length) {
-                questionPrompt = possiblesQuestions[categoryIndex];
-            }
+        if (categoryIndex !== -1 && categoryIndex < possiblesQuestions.length) {
+            questionPrompt = possiblesQuestions[categoryIndex];
+        }
 
         // Select a random query
         const randomQueryIndex = crypto.randomInt(0, queryPool.length);
@@ -166,6 +163,7 @@ async function loadQuestions(category = "All") {
         const data = response.data.results.bindings;
 
         // Generate all questions from this single dataset
+        console.log("Maxquestions: " + maxQuestions);
         for (let i = 0; i < maxQuestions; i++) {
             const question = generateQuestionFromData(data, randomQueryIndex);
             question.questionObject = questionPrompt || "¿Qué muestra esta imagen?";

--- a/questionservice/question-service.js
+++ b/questionservice/question-service.js
@@ -426,8 +426,15 @@ app.get('/nextQuestion', (req, res) => {
 // Carga de las queries según la categoría
 async function getQueriesByCategory(category = "All") {
     if (category === "All" || !category) {
-        let rand = crypto.randomInt(0, categories.length);
-        changeQueriesAndQuestions(categories[rand]);
+        queries = [];
+        for (let cat of categories) {
+            if (cat !== "All") {
+                queries = queries.concat(queriesAndQuestions["es"][cat]);
+            }
+        }
+
+        //let rand = crypto.randomInt(0, categories.length);
+        //changeQueriesAndQuestions(categories[rand]);
     }
     else {
         if (categories.includes(category)) {

--- a/questionservice/question-service.js
+++ b/questionservice/question-service.js
@@ -64,18 +64,29 @@ imagesQueries["es"] = {
 
     "Personajes":
         [
-            /* pregunta = imagen futbolista, opción = nombre futbolista */
+            /* pregunta = imagen de una persona famosa, opción = nombre de la persona */
             [
                 `
-      SELECT ?optionLabel ?imageLabel
-      WHERE {
-        ?option wdt:P106 wd:Q937857;     
-                wdt:P569 ?birthdate.     
-        FILTER(YEAR(?birthdate) >= 1970)  
-        ?option wdt:P18 ?imageLabel.     
-        SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es". }
-      }
-      LIMIT 30`, "¿Cuál es el nombre de este futbolista?"]
+        SELECT DISTINCT ?option ?optionLabel ?imageLabel
+        WHERE {
+        ?option wdt:P31 wd:Q5;               # Instance of human
+                rdfs:label ?optionLabel;       # Get their label/name
+                wdt:P106 ?occupation.          # Has occupation
+  
+         # Famous occupations filter
+         VALUES ?occupation { 
+            wd:Q33999   # Actor
+            wd:Q177220  # Singer
+            wd:Q937857  # Football player
+            wd:Q82955   # Politician
+            wd:Q36180   # Writer
+         }
+  
+        OPTIONAL { ?option wdt:P18 ?imageLabel. }    
+        FILTER(lang(?optionLabel) = "es")       
+        FILTER EXISTS { ?option wdt:P18 ?imageLabel }
+}
+LIMIT 30`, "¿Quién es esta persona famosa?"]
         ],
 
 
@@ -100,7 +111,7 @@ var queriesAndQuestions = getQueriesAndQuestions(imagesQueries); // almacena las
 
 
 
-var possiblesQuestions = ["¿Cuál es el lugar de la imagen?", "¿Qué monumento es este?", "¿Cuál es el nombre de este futbolista?", "¿Qué videojuego es este?", "¿Qué muestra esta imagen?"];
+var possiblesQuestions = ["¿Cuál es el lugar de la imagen?", "¿Qué monumento es este?", "¿Quién es esta persona famosa?", "¿Qué videojuego es este?", "¿Qué muestra esta imagen?"];
 var categories = ["Geografia", "Cultura", "Personajes", "Videojuegos", "All"];
 var questionObject = "";
 var correctAnswer = "";
@@ -535,7 +546,7 @@ app.get('/generatedQuestion', async (req, res) => {
 function getCategoryFromQuestion(questionText) {
     if (questionText.includes("lugar")) return "Geografia";
     if (questionText.includes("monumento")) return "Cultura";
-    if (questionText.includes("futbolista") || questionText.includes("personaje")) return "Personajes";
+    if (questionText.includes("famosa") || questionText.includes("personaje")) return "Personajes";
     return "General";
 }
 

--- a/webapp/src/components/game/Game.js
+++ b/webapp/src/components/game/Game.js
@@ -177,10 +177,6 @@ const Game = () => {
     navigate('/Home');
   };
 
-  const handleGoToProfile = () => {
-    navigate('/profile');
-  };
-
   const isGameFinished = () => {
     return questionCounter >= numberOfQuestions;
   };
@@ -269,7 +265,6 @@ const Game = () => {
                 <Toolbar style={{ display: 'flex', justifyContent: 'space-between' }}>
                   <Button color="inherit" onClick={handleHome}>Abandonar</Button>
                   <Button color="inherit" onClick={() => handleNewGame(location.state?.gameConfig?.category || "All")}>Reiniciar partida</Button>
-                  <Button color="inherit" onClick={handleGoToProfile}>Ir al perfil</Button>
                 </Toolbar>
               </AppBar>
 

--- a/webapp/src/components/home/Home.js
+++ b/webapp/src/components/home/Home.js
@@ -48,6 +48,7 @@ import PublicIcon from "@mui/icons-material/Public"
 import TheaterComedyIcon from "@mui/icons-material/TheaterComedy"
 import PersonIcon from "@mui/icons-material/Person"
 import ShuffleIcon from "@mui/icons-material/Shuffle"
+import SportsEsportsIcon from "@mui/icons-material/SportsEsports"
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown"
 import "./Home.css"
 
@@ -715,6 +716,12 @@ const HomePage = () => {
                           </ListItemIcon>
                           <ListItemText>Personajes</ListItemText>
                         </MenuItem>
+                          <MenuItem onClick={() => handleShowGame("Videojuegos")} sx={{ py: 1.5 }}>
+                              <ListItemIcon>
+                                  <SportsEsportsIcon fontSize="small" color="primary" />
+                              </ListItemIcon>
+                              <ListItemText>Videojuegos</ListItemText>
+                          </MenuItem>
                         <Divider />
                         <MenuItem onClick={() => handleShowGame("All")} sx={{ py: 1.5 }}>
                           <ListItemIcon>


### PR DESCRIPTION
Fix second game played only having one question and stopping.
Added category for videogames, configured its query, and added a button to the Home view.
Optimised questions generation to avoid repeated questions being shown.
Changed people query to include all kind of famous people, not only football players. Increases variety and, somehow, speed.
After all this changes: once again, fixed the "All" category. Now REALLY SHOULD work fine. Forever.