### PR TITLE
Game difficulty, session history, fix login

### DIFF
--- a/apiservice/api-service.js
+++ b/apiservice/api-service.js
@@ -39,7 +39,8 @@ app.get('/questions/:username', async (req, res) => {
                 sessionDate: session.createdAt,
                 score: session.score || 0,
                 wrongAnswers: session.wrongAnswers || 0,
-                questions: questionsWithoutId
+                questions: questionsWithoutId,
+                difficulty: session.difficulty
             };
         });
 

--- a/apiservice/api-service.js
+++ b/apiservice/api-service.js
@@ -40,7 +40,8 @@ app.get('/questions/:username', async (req, res) => {
                 score: session.score || 0,
                 wrongAnswers: session.wrongAnswers || 0,
                 questions: questionsWithoutId,
-                difficulty: session.difficulty
+                difficulty: session.difficulty,
+                category: session.category
             };
         });
 

--- a/apiservice/openapi.yaml
+++ b/apiservice/openapi.yaml
@@ -139,6 +139,9 @@ components:
           type: string
           format: date-time
           description: Date when the session was created
+        difficulty:
+          type: string
+          description: Difficulty level of the game
         score:
           type: integer
           description: Number of correct answers

--- a/users/sesionservice/sesionService.js
+++ b/users/sesionservice/sesionService.js
@@ -23,6 +23,8 @@ const userSchema = new mongoose.Schema({
         }],
       score: Number,
       wrongAnswers: Number,
+      difficulty: String,
+      category: String,
       createdAt: {
         type: Date,
         default: Date.now, 
@@ -39,7 +41,7 @@ app.get('/health', (req, res) => {
 });
 
 app.post('/save-session', async (req, res) => {
-  const { userid, score, wrongAnswers, questions } = req.body; // Agregar 'questions'
+  const { userid, score, wrongAnswers, questions, difficulty, category } = req.body; // Agregar 'questions'
 
   // Sanitize userid input
   if (!userid || typeof userid !== 'string') {
@@ -65,7 +67,9 @@ app.post('/save-session', async (req, res) => {
       user.sessions.push({ 
         score, 
         wrongAnswers, 
-        questions // Guardar las preguntas en la sesión
+        questions,
+        difficulty,
+        category
       });
       await user.save();
       res.status(200).json({ message: 'Session saved successfully' });

--- a/webapp/src/components/game/Game.js
+++ b/webapp/src/components/game/Game.js
@@ -192,6 +192,7 @@ const Game = () => {
         score: score,
         wrongAnswers: falladas,
         difficulty: difficulty,
+        category: localStorage.getItem('gameCategory') || "All",
       })
           .then(response => {
             console.log("Sesión guardada exitosamente:", response.data);
@@ -274,6 +275,8 @@ const Game = () => {
           question: question,
           correctAnswer: correctAnswer,
           userAnswer: "Tiempo agotado",
+          difficulty: location.state?.gameConfig?.difficulty || "Normal",
+          category: location.state?.gameConfig?.category || "All",
         }
       ]);
 

--- a/webapp/src/components/game/Game.test.js
+++ b/webapp/src/components/game/Game.test.js
@@ -206,6 +206,92 @@ it('the user answers the first question correctly', async () => {
       expect(nextQuestion).toHaveTextContent('¿Cuál es la capital de España?');
     });
   });
-  
+
+
+  describe('Game Component - Difficulties and Categories', () => {
+    const mockFirstQuestion = {
+      questionObject: '¿Cuál es la capital de España?',
+      questionImage: 'https://example.com/madrid.jpg',
+      correctAnswer: 'Madrid',
+      answerOptions: ['Londres', 'Lisboa', 'Madrid', 'Roma']
+    };
+
+    beforeEach(() => {
+      mockAxios.reset();
+      jest.useFakeTimers();
+
+      // Reset the mock implementation before each test
+      jest.spyOn(require('react-router-dom'), 'useLocation').mockImplementation(() => ({
+        state: {
+          gameConfig: {
+            numQuestions: 5,
+            timePerQuestion: 30,
+            difficulty: 'Normal' // Default
+          }
+        }
+      }));
+
+      mockAxios.onPost('http://localhost:8004/startGame').reply(200, {
+        message: 'Game started',
+        category: 'All',
+        firstQuestion: mockFirstQuestion
+      });
+    });
+
+    it('sets the correct time limit for "Principiante" difficulty', async () => {
+      // Override mock for this specific test
+      jest.spyOn(require('react-router-dom'), 'useLocation').mockImplementation(() => ({
+        state: {
+          gameConfig: {
+            numQuestions: 5,
+            timePerQuestion: 30,
+            difficulty: 'Principiante'
+          }
+        }
+      }));
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText(/Tiempo restante: 60s/i)).toBeInTheDocument();
+      });
+    });
+
+    it('sets the correct time limit for "Difícil" difficulty', async () => {
+      jest.spyOn(require('react-router-dom'), 'useLocation').mockImplementation(() => ({
+        state: {
+          gameConfig: {
+            numQuestions: 5,
+            timePerQuestion: 30,
+            difficulty: 'Difícil'
+          }
+        }
+      }));
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText(/Tiempo restante: 15s/i)).toBeInTheDocument();
+      });
+    });
+
+    it('sets the correct time limit for "Experto" difficulty', async () => {
+      jest.spyOn(require('react-router-dom'), 'useLocation').mockImplementation(() => ({
+        state: {
+          gameConfig: {
+            numQuestions: 5,
+            timePerQuestion: 30,
+            difficulty: 'Experto'
+          }
+        }
+      }));
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText(/Tiempo restante: 5s/i)).toBeInTheDocument();
+      });
+    });
+  });
   
 });

--- a/webapp/src/components/home/Home.js
+++ b/webapp/src/components/home/Home.js
@@ -134,7 +134,8 @@ const HomePage = () => {
             state: {
                 gameConfig: {
                     numQuestions: numQuestions,
-                    difficulty: difficultyN
+                    difficulty: difficultyN,
+                    category: category,
                 },
             },
         })
@@ -1141,6 +1142,19 @@ const HomePage = () => {
                                                                                 {session.difficulty}
                                                                             </Typography>
 
+                                                                            <Typography
+                                                                                variant="caption"
+                                                                                color="text.secondary"
+                                                                                sx={{
+                                                                                    display: "flex",
+                                                                                    alignItems: "center",
+                                                                                    gap: 0.5,
+                                                                                }}
+                                                                            >
+                                                                                <SportsEsportsIcon fontSize="inherit" />
+                                                                                {session.category}
+                                                                            </Typography>
+
                                                                         </Box>
                                                                     </Grid>
                                                                     <Grid item xs={6} sm={4}>
@@ -1235,7 +1249,7 @@ const HomePage = () => {
                             }}
                         >
                             <Typography variant="h6" component="div" fontWeight="bold">
-                                Detalles de la sesión del {formatDate(selectedSession.createdAt).split(" ")[0]}
+                                Detalles de la sesión del {formatDate(selectedSession.createdAt).split(" ")[0]} con dificultad {selectedSession.difficulty}
                             </Typography>
                             <IconButton edge="end" color="inherit" onClick={handleCloseDialog} aria-label="close">
                                 <CloseIcon />

--- a/webapp/src/components/home/Home.js
+++ b/webapp/src/components/home/Home.js
@@ -69,7 +69,7 @@ const HomePage = () => {
     const theme = useTheme()
 
     // Configuración de la partida
-    const [numQuestions, setNumQuestions] = useState(5)
+    const [numQuestions, setNumQuestions] = useState(10)
     const [timePerQuestion, setTimePerQuestion] = useState(30)
     const [sessionData, setSessionData] = useState([])
     const [loading, setLoading] = useState(true)
@@ -80,6 +80,24 @@ const HomePage = () => {
     // Estado para el menú desplegable
     const [anchorEl, setAnchorEl] = useState(null)
     const openMenu = Boolean(anchorEl)
+
+    const [difficulty, setDifficulty] = useState("Normal");
+    const [anchorElDifficulty, setAnchorElDifficulty] = useState(null);
+    const openDifficultyMenu = Boolean(anchorElDifficulty);
+
+    const handleOpenDifficultyMenu = (event) => {
+        setAnchorElDifficulty(event.currentTarget);
+    };
+
+    const handleCloseDifficultyMenu = () => {
+        setAnchorElDifficulty(null);
+    };
+
+    const handleSelectDifficulty = (selectedDifficulty) => {
+        setDifficulty(selectedDifficulty);
+        setNewTimePerQuestion(selectedDifficulty);
+        handleCloseDifficultyMenu();
+    };
 
     // Colors for the pie chart - más vibrantes y con mejor contraste
     const COLORS = ["#4CAF50", "#FF5252"]
@@ -108,7 +126,7 @@ const HomePage = () => {
         }
     }, [username])
 
-    const handleShowGame = (category = "All") => {
+    const handleShowGame = (category = "All", difficultyN = "Normal") => {
         // Log the selected category before navigation
         console.log("Starting game with category:", category)
 
@@ -116,8 +134,7 @@ const HomePage = () => {
             state: {
                 gameConfig: {
                     numQuestions: numQuestions,
-                    timePerQuestion: timePerQuestion,
-                    category: category,
+                    difficulty: difficultyN
                 },
             },
         })
@@ -211,7 +228,8 @@ const HomePage = () => {
         if (totalQuestions < 30) return { level: "Aprendiz", color: "#8BC34A" }
         if (totalQuestions < 60) return { level: "Intermedio", color: "#03A9F4" }
         if (totalQuestions < 100) return { level: "Avanzado", color: "#FF9800" }
-        return { level: "Experto", color: "#F44336" }
+        if (totalQuestions < 200) return { level: "Experto", color: "#F44336" }
+        return { level: "Generalísimo", color: "#3c8841" }
     }
 
     const playerLevel = getPlayerLevel()
@@ -245,6 +263,31 @@ const HomePage = () => {
   };
 
   const [showMessage, setShowMessage] = useState("");
+
+    /**
+     * This function is used only to adapt the label that informs about the time per question to the user
+     * @param difficulty Difficulty selected by the user
+     */
+  function setNewTimePerQuestion(difficulty) {
+    switch (difficulty) {
+      case "Principiante":
+        setTimePerQuestion(60);
+        break;
+      case "Normal":
+        setTimePerQuestion(30);
+        break;
+      case "Difícil":
+        setTimePerQuestion(15);
+        break;
+      case "Experto":
+        setTimePerQuestion(5);
+        break;
+      default:
+        setTimePerQuestion(30);
+    }
+  }
+
+
 
   return (
     <ConfigContext.Provider value={configValue}>
@@ -715,7 +758,109 @@ const HomePage = () => {
                                                 Jugar ahora
                                             </Typography>
 
-                                            {/* Botón principal con menú desplegable */}
+                                            <Box sx={{ mt: 0.5 }}></Box>
+
+                                            <Typography
+                                                variant="h6"
+                                                gutterBottom
+                                                align="center"
+                                                sx={{
+                                                    mb: 1,
+                                                    position: "relative",
+                                                    zIndex: 1,
+                                                }}
+                                            >
+                                                Seleccionar dificultad
+                                            </Typography>
+
+                                            <Button
+                                                variant="contained"
+                                                size="large"
+                                                onClick={handleOpenDifficultyMenu}
+                                                endIcon={<KeyboardArrowDownIcon />}
+                                                sx={{
+                                                    py: 1.5,
+                                                    px: 4,
+                                                    borderRadius: 8,
+                                                    fontWeight: "bold",
+                                                    textTransform: "none",
+                                                    fontSize: "1.1rem",
+                                                    bgcolor: "white",
+                                                    color: theme.palette.warning.dark,
+                                                    boxShadow: "0 10px 20px rgba(0, 0, 0, 0.1)",
+                                                    position: "relative",
+                                                    zIndex: 1,
+                                                    "&:hover": {
+                                                        bgcolor: "white",
+                                                        boxShadow: "0 15px 25px rgba(0, 0, 0, 0.15)",
+                                                        transform: "translateY(-3px)",
+                                                        transition: "all 0.3s",
+                                                    },
+                                                }}
+                                            >
+                                                {difficulty}
+                                            </Button>
+
+                                            <Menu
+                                                id="difficulty-menu"
+                                                anchorEl={anchorElDifficulty}
+                                                open={openDifficultyMenu}
+                                                onClose={handleCloseDifficultyMenu}
+                                                MenuListProps={{
+                                                    "aria-labelledby": "difficulty-button",
+                                                }}
+                                                PaperProps={{
+                                                    elevation: 3,
+                                                    sx: {
+                                                        mt: 1,
+                                                        borderRadius: 2,
+                                                        minWidth: 200,
+                                                        overflow: "visible",
+                                                        "&:before": {
+                                                            content: '""',
+                                                            display: "block",
+                                                            position: "absolute",
+                                                            top: 0,
+                                                            right: 14,
+                                                            width: 10,
+                                                            height: 10,
+                                                            bgcolor: "background.paper",
+                                                            transform: "translateY(-50%) rotate(45deg)",
+                                                            zIndex: 0,
+                                                        },
+                                                    },
+                                                }}
+                                                transformOrigin={{ horizontal: "right", vertical: "top" }}
+                                                anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+                                            >
+                                                <MenuItem onClick={() => handleSelectDifficulty("Principiante")}>
+                                                    <ListItemIcon>
+                                                        <SportsEsportsIcon fontSize="small" color="primary" />
+                                                    </ListItemIcon>
+                                                    <ListItemText>Principiante</ListItemText>
+                                                </MenuItem>
+                                                <MenuItem onClick={() => handleSelectDifficulty("Normal")}>
+                                                    <ListItemIcon>
+                                                        <SportsEsportsIcon fontSize="small" color="primary" />
+                                                    </ListItemIcon>
+                                                    <ListItemText>Normal</ListItemText>
+                                                </MenuItem>
+                                                <MenuItem onClick={() => handleSelectDifficulty("Difícil")}>
+                                                    <ListItemIcon>
+                                                        <SportsEsportsIcon fontSize="small" color="primary" />
+                                                    </ListItemIcon>
+                                                    <ListItemText>Difícil</ListItemText>
+                                                </MenuItem>
+                                                <MenuItem onClick={() => handleSelectDifficulty("Experto")}>
+                                                    <ListItemIcon>
+                                                        <SportsEsportsIcon fontSize="small" color="primary" />
+                                                    </ListItemIcon>
+                                                    <ListItemText>Experto</ListItemText>
+                                                </MenuItem>
+                                            </Menu>
+
+                                            <Box sx={{ mt: 2.5 }}></Box>
+
                                             <Button
                                                 variant="contained"
                                                 size="large"
@@ -749,8 +894,10 @@ const HomePage = () => {
                                                 Comenzar partida
                                             </Button>
 
+
                                             {/* Menú desplegable con opciones de juego */}
                                             <Menu
+                                                sx={{ mt: 2 }}
                                                 id="game-menu"
                                                 anchorEl={anchorEl}
                                                 open={openMenu}
@@ -782,38 +929,38 @@ const HomePage = () => {
                                                 transformOrigin={{ horizontal: "right", vertical: "top" }}
                                                 anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
                                             >
-                                                <MenuItem onClick={() => handleShowGame("Geografia")} sx={{ py: 1.5 }}>
+                                                <MenuItem onClick={() => handleShowGame("Geografia", difficulty)} sx={{ py: 1.5 }}>
                                                     <ListItemIcon>
                                                         <PublicIcon fontSize="small" color="primary" />
                                                     </ListItemIcon>
                                                     <ListItemText>Geografía</ListItemText>
                                                 </MenuItem>
-                                                <MenuItem onClick={() => handleShowGame("Cultura")} sx={{ py: 1.5 }}>
+                                                <MenuItem onClick={() => handleShowGame("Cultura", difficulty)} sx={{ py: 1.5 }}>
                                                     <ListItemIcon>
                                                         <TheaterComedyIcon fontSize="small" color="primary" />
                                                     </ListItemIcon>
                                                     <ListItemText>Cultura</ListItemText>
                                                 </MenuItem>
-                                                <MenuItem onClick={() => handleShowGame("Personajes")} sx={{ py: 1.5 }}>
+                                                <MenuItem onClick={() => handleShowGame("Personajes", difficulty)} sx={{ py: 1.5 }}>
                                                     <ListItemIcon>
                                                         <PersonIcon fontSize="small" color="primary" />
                                                     </ListItemIcon>
                                                     <ListItemText>Personajes</ListItemText>
                                                 </MenuItem>
-                                                <MenuItem onClick={() => handleShowGame("Videojuegos")} sx={{ py: 1.5 }}>
+                                                <MenuItem onClick={() => handleShowGame("Videojuegos", difficulty)} sx={{ py: 1.5 }}>
                                                     <ListItemIcon>
                                                         <SportsEsportsIcon fontSize="small" color="primary" />
                                                     </ListItemIcon>
                                                     <ListItemText>Videojuegos</ListItemText>
                                                 </MenuItem>
-                                                <MenuItem onClick={() => handleShowGame("Aviones")} sx={{ py: 1.5 }}>
+                                                <MenuItem onClick={() => handleShowGame("Aviones", difficulty)} sx={{ py: 1.5 }}>
                                                     <ListItemIcon>
                                                         <FlightIcon fontSize="small" color="primary" />
                                                     </ListItemIcon>
                                                     <ListItemText>Aviones</ListItemText>
                                                 </MenuItem>
                                                 <Divider />
-                                                <MenuItem onClick={() => handleShowGame("All")} sx={{ py: 1.5 }}>
+                                                <MenuItem onClick={() => handleShowGame("All", difficulty)} sx={{ py: 1.5 }}>
                                                     <ListItemIcon>
                                                         <ShuffleIcon fontSize="small" color="primary" />
                                                     </ListItemIcon>
@@ -980,6 +1127,20 @@ const HomePage = () => {
                                                                                 <AccessTimeIcon fontSize="inherit" />
                                                                                 {formatDate(session.createdAt).split(" ")[1]}
                                                                             </Typography>
+
+                                                                            <Typography
+                                                                                variant="caption"
+                                                                                color="text.secondary"
+                                                                                sx={{
+                                                                                    display: "flex",
+                                                                                    alignItems: "center",
+                                                                                    gap: 0.5,
+                                                                                }}
+                                                                            >
+                                                                                <QuizIcon fontSize="inherit" />
+                                                                                {session.difficulty}
+                                                                            </Typography>
+
                                                                         </Box>
                                                                     </Grid>
                                                                     <Grid item xs={6} sm={4}>

--- a/webapp/src/components/login/Login.js
+++ b/webapp/src/components/login/Login.js
@@ -15,7 +15,6 @@ const Login = () => {
   const [openSnackbar, setOpenSnackbar] = useState(false);
 
   const apiEndpoint = process.env.REACT_APP_API_ENDPOINT || 'http://localhost:8000';
-  const apiKey = process.env.REACT_APP_LLM_API_KEY || 'None';
   
   const navigate = useNavigate();
 
@@ -25,16 +24,6 @@ const Login = () => {
 
       localStorage.setItem('username', username);
 
-      const question = "Please, generate a greeting message for a student called " + username + " that is a student of the Software Architecture course in the University of Oviedo. Be nice and polite. Two to three sentences max.";
-      const model = "empathy"
-
-      if (apiKey==='None'){
-        setMessage("LLM API key is not set. Cannot contact the LLM.");
-      }
-      else{
-        const message = await axios.post(`${apiEndpoint}/askllm`, { question, model, apiKey })
-        setMessage(message.data.answer);
-      }
       // Extract data from the response
       const { createdAt: userCreatedAt } = response.data;
 

--- a/webapp/src/components/profile/Profile.js
+++ b/webapp/src/components/profile/Profile.js
@@ -42,6 +42,7 @@ import CloseIcon from "@mui/icons-material/Close"
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import './Profile.css';
+import SportsEsportsIcon from "@mui/icons-material/SportsEsports";
 
 const Profile = () => {
   const navigate = useNavigate();
@@ -785,6 +786,19 @@ const Profile = () => {
                                               {session.difficulty}
                                           </Typography>
 
+                                          <Typography
+                                              variant="caption"
+                                              color="text.secondary"
+                                              sx={{
+                                                  display: "flex",
+                                                  alignItems: "center",
+                                                  gap: 0.5,
+                                              }}
+                                          >
+                                              <SportsEsportsIcon fontSize="inherit" />
+                                              {session.category}
+                                          </Typography>
+
                                       </Box>
                                     </Grid>
                                     <Grid item xs={6} sm={4}>
@@ -888,7 +902,7 @@ const Profile = () => {
                 }}
               >
                 <Typography variant="h6" component="div" fontWeight="bold">
-                  Detalles de la sesión del {formatDate(selectedSession.createdAt).split(" ")[0]}
+                    Detalles de la sesión del {formatDate(selectedSession.createdAt).split(" ")[0]} con dificultad {selectedSession.difficulty}
                 </Typography>
                 <IconButton edge="end" color="inherit" onClick={handleCloseSessionDialog} aria-label="close">
                   <CloseIcon />

--- a/webapp/src/components/profile/Profile.js
+++ b/webapp/src/components/profile/Profile.js
@@ -771,6 +771,20 @@ const Profile = () => {
                                           <AccessTimeIcon fontSize="inherit" />
                                           {formatDate(session.createdAt).split(" ")[1]}
                                         </Typography>
+
+                                          <Typography
+                                              variant="caption"
+                                              color="text.secondary"
+                                              sx={{
+                                                  display: "flex",
+                                                  alignItems: "center",
+                                                  gap: 0.5,
+                                              }}
+                                          >
+                                              <QuizIcon fontSize="inherit" />
+                                              {session.difficulty}
+                                          </Typography>
+
                                       </Box>
                                     </Grid>
                                     <Grid item xs={6} sm={4}>


### PR DESCRIPTION
- Cambiado el login para que no haga una petición inútil al LLM (ralentizaba sobremanera la UX).
- Se añade toda la lógica para tener varias dificultades en el juego, seleccionables por el usuario, las cuales cambian el tiempo disponible para responder.
- Añadido también un front end provisional o definitivo si no hay queja.
- Cambiado el número de preguntas por partida de 5 a 10.
- El historial de partidas ahora muestra también las categorías y dificultades, tanto en Home como en Profile.
- Otras correcciones menores.